### PR TITLE
Serialise exp and iat as Int

### DIFF
--- a/jwt.ml
+++ b/jwt.ml
@@ -237,7 +237,12 @@ let payload_of_string str =
 let json_of_payload payload =
   let members =
     map
-      (fun (claim, value) -> ((string_of_claim claim), `String value))
+      (fun (claim, value) -> 
+        match string_of_claim claim with
+        | "exp"
+        | "iat" -> ((string_of_claim claim), `Int (int_of_string value))
+        | _ -> ((string_of_claim claim), `String value)
+      )
       payload
   in
   `Assoc members


### PR DESCRIPTION
This fixes serialisation of `exp` and `iat` to be numbers, there are probably more cases that needs to be covered but this is a start.